### PR TITLE
Changes for openHAB 5

### DIFF
--- a/bundles/org.openhab.binding.apsystemsez1/pom.xml
+++ b/bundles/org.openhab.binding.apsystemsez1/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>4.3.0-SNAPSHOT</version>
+    <version>5.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.apsystemsez1</artifactId>

--- a/bundles/org.openhab.binding.apsystemsez1/src/main/java/org/openhab/binding/apsystemsez1/internal/APsystemsEZ1BindingConstants.java
+++ b/bundles/org.openhab.binding.apsystemsez1/src/main/java/org/openhab/binding/apsystemsez1/internal/APsystemsEZ1BindingConstants.java
@@ -88,16 +88,16 @@ public class APsystemsEZ1BindingConstants {
 
     public static final Map<Class<? extends EZ1ResponseData>, List<String>> RESPONSE_DATA_CHANNEL_UID_LIST_MAP = Map
             .ofEntries(Map.entry(EZ1DeviceInfoResponseData.class, List.of()), Map.entry(EZ1OutputDataResponseData.class,
-                    List.of(CHANNEL_GROUP_DC1 + ":" + CHANNEL_POWER, CHANNEL_GROUP_DC1 + ":" + CHANNEL_ENERGY_START,
-                            CHANNEL_GROUP_DC1 + ":" + CHANNEL_ENERGY_LIFETIME, CHANNEL_GROUP_DC2 + ":" + CHANNEL_POWER,
-                            CHANNEL_GROUP_DC2 + ":" + CHANNEL_ENERGY_START,
-                            CHANNEL_GROUP_DC2 + ":" + CHANNEL_ENERGY_LIFETIME,
-                            CHANNEL_GROUP_DEVICE + ":" + CHANNEL_POWER,
-                            CHANNEL_GROUP_DEVICE + ":" + CHANNEL_ENERGY_START,
-                            CHANNEL_GROUP_DEVICE + ":" + CHANNEL_ENERGY_LIFETIME)),
-                    Map.entry(EZ1MaxPowerResponseData.class, List.of(CHANNEL_GROUP_DEVICE + ":" + CHANNEL_MAX_PWR)),
-                    Map.entry(EZ1AlarmResponseData.class, List.of(CHANNEL_GROUP_DEVICE + ":" + CHANNEL_ALARM_OE,
-                            CHANNEL_GROUP_DEVICE + ":" + CHANNEL_ALARM_OG, CHANNEL_GROUP_DC1 + ":" + CHANNEL_ALARM_ISCE,
-                            CHANNEL_GROUP_DC2 + ":" + CHANNEL_ALARM_ISCE)),
-                    Map.entry(EZ1OnOffResponseData.class, List.of(CHANNEL_GROUP_DEVICE + ":" + CHANNEL_STATUS)));
+                    List.of(CHANNEL_GROUP_DC1 + "#" + CHANNEL_POWER, CHANNEL_GROUP_DC1 + "#" + CHANNEL_ENERGY_START,
+                            CHANNEL_GROUP_DC1 + "#" + CHANNEL_ENERGY_LIFETIME, CHANNEL_GROUP_DC2 + "#" + CHANNEL_POWER,
+                            CHANNEL_GROUP_DC2 + "#" + CHANNEL_ENERGY_START,
+                            CHANNEL_GROUP_DC2 + "#" + CHANNEL_ENERGY_LIFETIME,
+                            CHANNEL_GROUP_DEVICE + "#" + CHANNEL_POWER,
+                            CHANNEL_GROUP_DEVICE + "#" + CHANNEL_ENERGY_START,
+                            CHANNEL_GROUP_DEVICE + "#" + CHANNEL_ENERGY_LIFETIME)),
+                    Map.entry(EZ1MaxPowerResponseData.class, List.of(CHANNEL_GROUP_DEVICE + "#" + CHANNEL_MAX_PWR)),
+                    Map.entry(EZ1AlarmResponseData.class, List.of(CHANNEL_GROUP_DEVICE + "#" + CHANNEL_ALARM_OE,
+                            CHANNEL_GROUP_DEVICE + "#" + CHANNEL_ALARM_OG, CHANNEL_GROUP_DC1 + "#" + CHANNEL_ALARM_ISCE,
+                            CHANNEL_GROUP_DC2 + "#" + CHANNEL_ALARM_ISCE)),
+                    Map.entry(EZ1OnOffResponseData.class, List.of(CHANNEL_GROUP_DEVICE + "#" + CHANNEL_STATUS)));
 }

--- a/bundles/org.openhab.binding.apsystemsez1/src/main/java/org/openhab/binding/apsystemsez1/internal/APsystemsEZ1Handler.java
+++ b/bundles/org.openhab.binding.apsystemsez1/src/main/java/org/openhab/binding/apsystemsez1/internal/APsystemsEZ1Handler.java
@@ -263,11 +263,26 @@ public class APsystemsEZ1Handler extends BaseThingHandler {
     private <T extends EZ1ResponseData> T parseResponse(Class<T> type, ContentResponse response) {
         var gsonObj = new Gson();
         logger.trace("Raw Response: {}", response.getContentAsString());
-        var returnData = gsonObj.fromJson(response.getContentAsString(), type);
-        if (returnData == null) {
+
+        // 1. Parse into a local variable first
+        T returnData;
+        try {
+            // We try to assign the value.
+            // If this fails, the catch block takes over.
+            var parsed = gsonObj.fromJson(response.getContentAsString(), type);
+            if (parsed == null) {
+                throw new JsonSyntaxException("Parsed JSON is null");
+            }
+            returnData = parsed;
+        } catch (Exception e) {
+            logger.warn("Failed to parse EZ1 response: '{}'. Error: {}", response.getContentAsString(), e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "@text/error.invalid.data");
+            // 2. Return null here because the method signature likely allows it
+            // OR it handles the failure at a higher level.
+            return null;
         }
 
+        // 3. If we reached this point, returnData is guaranteed to be initialized and Non-Null
         return returnData;
     }
 


### PR DESCRIPTION
* Change ':' to '#' in channel names (thanks to kolli in openHAB Forum)
* Catch empty json response from inverter. Fixes binding receiving no more data from inverter

Works for me (tested for ca. 1 week).

Caveat: The "Total Energy" channel seems broken: I have a daily discrepancy between "Total Energy" and "Energy produced since Powerup". I believe this is unrelated to the changes in this PR, though.